### PR TITLE
Readd python image

### DIFF
--- a/python/string-formatting/decision_tree.png
+++ b/python/string-formatting/decision_tree.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80feddff86060ab033afc5f527d3fa60bf0505e97a5a09e13320cd5811737617
+size 33429


### PR DESCRIPTION
The image was previously uploaded without using git lfs. It bricked the repo for me due to the following error:

```
Encountered 1 file(s) that should have been pointers, but weren't:
        python/string-formatting/decision_tree.png
```

cc @exercism/python I hope this didn't break anything for you.